### PR TITLE
fix in install script, must use sudo for systemctl enable restart_joy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,4 +44,4 @@ sudo systemctl start robot
 
 sudo mv restart_joy.service /lib/systemd/system/
 sudo mv joystart.sh /sbin/
-systemctl enable restart_joy
+sudo systemctl enable restart_joy


### PR DESCRIPTION
This fix is required for automated installation