### PR TITLE
Feature/fix install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,5 @@ cd StanfordQuadruped
 ./install.sh
 ```
 
-configure the network, this will overwrite your current network configuration, enable the wireless network and breate a bridge interface with the IP address of 10.0.0.10/24 as required by UDPComms. This will not work if any of your interfaces is already connected to the 10.0.0.0/24 network. The network configuration becomes active with the next reboot.
-
-```
-./configure_network.sh <SSID> <password>
-sudo reboot
-```
-
-
 If you want to use the web browser or keyboard to control your Mini Pupper, please continue to [here](https://github.com/mangdangroboticsclub/mini_pupper_web_controller).
 

--- a/install.sh
+++ b/install.sh
@@ -22,11 +22,6 @@ sudo pip install numpy transforms3d pyserial
 sudo pip install numpy transforms3d pyserial
 sudo apt-get install -y unzip
 
-# add bridge to network configuration
-$BASEDIR/configure_network.sh
-# reconfigure network each time network configuration has changed
-echo $BASEDIR/configure_network.sh >> /home/ubuntu/mini_pupper_bsp/System/check-reconfigure.sh
-
 cd ~
 git clone https://github.com/stanfordroboticsclub/PupperCommand.git
 cd PupperCommand
@@ -43,6 +38,11 @@ git clone https://github.com/stanfordroboticsclub/PS4Joystick.git
 cd PS4Joystick
 sed -i "s/pi/ubuntu/" joystick.service
 sudo bash install.sh
+
+# add bridge to network configuration
+$BASEDIR/configure_network.sh
+# reconfigure network each time network configuration has changed
+echo $BASEDIR/configure_network.sh >> /home/ubuntu/mini_pupper_bsp/System/check-reconfigure.sh
 
 cd ~
 sudo systemctl enable joystick


### PR DESCRIPTION
The configure_network.sh script will modify network setting. It sleeps for 5s and then the install.sh will continue execute git clone. However, the wifi may not be connected by this time.

 So we often encounter **issue** like below
```
fatal: unable to access 'https://github.com/stanfordroboticsclub/UDPComms.git/': Could not resolve host: github.com
fatal: unable to access 'https://github.com/stanfordroboticsclub/PS4Joystick.git/': Could not resolve host: github.com
```

**The solution** is to put network change after we finish all git clone


This pr also removed outdated instruction in README.md