### PR TITLE
Update install.sh: Add support for Ubuntu 24.04

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,9 +3,9 @@
 # check Ubuntu version
 source /etc/os-release
 
-if [[ $UBUNTU_CODENAME != 'jammy' ]]
+if [[ $UBUNTU_CODENAME != 'jammy' && $UBUNTU_CODENAME != 'noble']]
 then
-    echo "Ubuntu 22.04.1 LTS (Jammy Jellyfish) is required"
+    echo "Ubuntu 22.04.1 LTS (Jammy Jellyfish) is required or Ubuntu 24.04 LTS (noble)"
     echo "You are using $VERSION"
     exit 1
 fi


### PR DESCRIPTION
## Summary
This PR adds support for Ubuntu 24.04 to the install.sh script.

## Changes
- Updated install.sh to detect and handle Ubuntu 24.04
- Previously only supported Ubuntu 22.04 and earlier

## Problem Solved
The installation script was failing on Ubuntu 24.04 systems. This update ensures Mini Pupper software can be installed on the latest Ubuntu LTS release.
